### PR TITLE
Replace embedded image of math with inline mathtex

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ This C++ template header-only library implements drop-in big decimal float types
 such as `dec51_t`, `dec101_t`, `dec1001_t`, `dec10001_t`, `dec1000001_t`, etc.,
 that can be used essentially like regular built-in floating-point types.
 Wide-decimal supports decimal float types having digit counts ranging
-roughly from about
-![digitrange](https://latex.codecogs.com/svg.image?{\sim}10{\ldots}10,000,000)
+roughly from about ${\sim}10{\ldots}10,000,000$
 
 Wide-decimal implements both common algebraic operations as well as
 a few common `<cmath>`-like functions such as `fabs`, `sqrt` and `log`,


### PR DESCRIPTION
Unlike the previous version, this one is readable on Github darkmode.

Before:
![image](https://user-images.githubusercontent.com/8693463/179342174-dd415e4d-4980-4e39-99ba-121b4ce928ec.png)

After:
![image](https://user-images.githubusercontent.com/8693463/179342192-d025e492-e41c-48dc-841e-e64cbe9d7a04.png)
